### PR TITLE
Upkeep / support for Kube 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,19 @@ After answering a few questions about your app, this tool can:
 Usage: deploy-node-app [env]
 
 Options:
-  -V, --version              output the version number
-  -n, --no-build             Don't build and push docker container
-  -d, --no-deploy            Don't deploy to kubernetes
-  -O, --overwrite            Overwrite local files
-  -s, --skip [metamodule]   name of metamodule to skip
-  -f, --format [type]        Output config format [k8s|compose] (default: "compose")
-  -o, --output [filename]    File for config output. "-" will write to stdout. Default is docker-compose.yaml or deployment.yaml depending on format
-  --generate-default-env     Generates default environment variables, like database passwords
-  --generate-local-ports-env Generates environment variables for connecting to docker-compose services
-  -h, --help                 output usage information
+  -V, --version               output the version number
+  --generate-default-env      Generates default environment variables, like database passwords
+  --generate-local-ports-env  Generates environment variables for connecting to docker-compose services
+  -n, --no-build              Don't build and push docker container
+  -N, --no-confirm            Skip public docker hub confirmation prompt
+  -d, --no-push               Don't push to docker registry
+  -D, --no-deploy             Don't deploy to kubernetes
+  -O, --overwrite             Overwrite local files
+  -s, --skip metamodule       name of metamodule to skip
+  -S, --safe                  Do not overwrite local files
+  -f, --format [type]         Output config format [k8s|compose] (default: "k8s")
+  -o, --output [filename]     File for config output. "-" will write to stdout. Default is docker-compose.yaml or deployment.yaml depending on format
+  -h, --help                  output usage information
 ```
 
 By default, `deploy-node-app` will write a few files to your directory, depending on the chosen output. You will be prompted if any files need to be updated or overwritten (use --overwrite to ignore prompts).

--- a/src/defaults/backend-deployment.yaml
+++ b/src/defaults/backend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/src/defaults/frontend-deployment.yaml
+++ b/src/defaults/frontend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/src/index.js
+++ b/src/index.js
@@ -34,11 +34,12 @@ program
     'Generates environment variables for connecting to docker-compose services'
   )
   .option('-n, --no-build', 'Don\'t build and push docker container')
-  .option('-n, --no-confirm', 'Skip public docker hub confirmation prompt')
+  .option('-N, --no-confirm', 'Skip public docker hub confirmation prompt')
   .option('-d, --no-push', 'Don\'t push to docker registry')
-  .option('-d, --no-deploy', 'Don\'t deploy to kubernetes')
+  .option('-D, --no-deploy', 'Don\'t deploy to kubernetes')
   .option('-O, --overwrite', 'Overwrite local files')
   .option('-s, --skip metamodule', 'name of metamodule to skip')
+  .option('-i, --images', 'Images only - build and push, but only change local image tags, no other local changes')
   .option('-f, --format [type]', 'Output config format [k8s|compose]', 'k8s')
   .option(
     '-o, --output [filename]',


### PR DESCRIPTION
- Update deployment yaml apiVersion (DNA is broken on Kubectl 1.16+ 😢)
- add -i option for images only (Not 100% working as intended, idea being "I only want to update image refs, please don't change my custom yaml!)
- don't add /api location if no backend was added (this crashes SPA applications deployed via nginx currently with a "host not found in upstream" error)

@pastudan 