### PR TITLE
Add support for networks and volumes in compose file

### DIFF
--- a/src/deployNodeApp.js
+++ b/src/deployNodeApp.js
@@ -168,20 +168,39 @@ async function deployNodeApp (packageJson /*: Object */, env /*: string */, opts
 
   function buildComposeFile (metaModules /*: Array<Object> */) {
     let services = {}
+    let networks = {}
+    let volumes = {}
     metaModules.forEach(dependency => {
       const filename = `./node_modules/${dependency.name}/docker-compose.yaml`
       if (fs.existsSync(filename)) {
         const config = yaml.safeLoad(fs.readFileSync(filename))
         services = Object.assign({}, services, config.services)
+        networks = Object.assign({}, networks, config.networks)
+        volumes = Object.assign({}, volumes, config.volumes)
       } else {
         process.stdout.write('Warning:', dependency.name, 'doesn\'t support Docker Compose mode\n')
       }
     })
 
-    return {
+    let file = {
       version: '3',
       services
     }
+
+    // Only add objects that aren't empty
+    if (JSON.stringify(networks) !== '{}') {
+      file = {
+        ...file,
+        networks
+      }
+    }
+    if (JSON.stringify(volumes) !== '{}') {
+      file = {
+        ...file,
+        volumes
+      }
+    }
+    return file
   }
 
   async function buildKustomize (


### PR DESCRIPTION
This PR adds the required functionality for **networks** and **volumes** to be specified in a metamodule's configuration file.

On top of **services**, docker-compose allows for further configuration related to the data storage and networking, which can be extremely useful for metamodules related to databases (such as Mongo and Postgres) and various other cases.

As such, I believe this change is useful to allow for further modularity when one develops a metamodule.

Let me know if you need any changes to be made before merging this!