### PR TITLE
Fix execSyncWithEnv overriding catchErr as true

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,10 +22,10 @@ function fatal (message /*: string */) {
 }
 
 const execSyncWithEnv = (cmd, options = {}) => {
-  const mergedOpts = Object.assign({}, options, {
+  const mergedOpts = Object.assign({}, {
     catchErr: true,
     env: Object.assign({}, process.env, options.env)
-  })
+  }, options)
   let output
   try {
     output = execSync(cmd, mergedOpts)


### PR DESCRIPTION
I noticed that whenever the `checkForGitIgnored` function failed, the app would stop instead of displaying a warning, even though the option **catchErr** is implicitly set to false.

After checking the `execSyncWithEnv` function, it seems like that option is always overridden to true, which is probably unintentional since there's a conditional check on its value and the app exits if it's set to true.

This PR fixes this issue by setting the options on top of the default value instead.